### PR TITLE
docs: fix typo on deprecated alerts

### DIFF
--- a/projects/hx-ui/CHANGELOG.md
+++ b/projects/hx-ui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/MedicalDirector/hxui-angular/compare/v11.2.1...HEAD)
 
-## [11.2.1](https://github.com/MedicalDirector/hxui-angular/compare/v11.2.0...v11.2.1) - 2022-05-19
+<!-- ## [11.2.1](https://github.com/MedicalDirector/hxui-angular/compare/v11.2.0...v11.2.1) - 2022-05-25 -->
 
 ### Fixed
 

--- a/src/app/core/modals/modals.component.html
+++ b/src/app/core/modals/modals.component.html
@@ -15,7 +15,7 @@
       </span>
       <span class="hx-flex-1">
         This component is currently deprecated and will be removed in the next
-        major update in the next major update.
+        major update.
       </span>
     </div>
 

--- a/src/app/core/selectize/selectize.component.html
+++ b/src/app/core/selectize/selectize.component.html
@@ -17,7 +17,7 @@
       </span>
       <span class="hx-flex-1">
         This component is currently deprecated and will be removed in the next
-        major update in the next major update.
+        major update.
       </span>
     </div>
 


### PR DESCRIPTION
### Description

Fix typo in docs for deprecated alerts

### Change

- ~~[ ] Bug fix (non-breaking change, fixes an issue)~~
- ~~[ ] New feature (non-breaking change, adds functionality)~~
- ~~[ ] Breaking change (causing existing functionality to not work as expected)~~
- [x] This change requires a documentation update

### Checklist

- [x] I have self-reviewed my code
- ~~[ ] I have added comments to my code for hard-to-understand areas~~
- ~~[ ] I have added tests that confirm my code works as intended~~
