### PR TITLE
fix(ng-select): dom-independent multi-select dropdown styles

### DIFF
--- a/projects/ng-select/CHANGELOG.md
+++ b/projects/ng-select/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Styling for `ng-select-multiple` dropdown no longer depends on its location in the dom
+
 ## [1.1.1](https://www.npmjs.com/package/@hxui/ng-select/v/1.1.1) (2022-07-05)
 
 ### Fixed

--- a/projects/ng-select/themes/hxui.theme.scss
+++ b/projects/ng-select/themes/hxui.theme.scss
@@ -297,19 +297,6 @@ $ng-select-danger: #b81e4f;
         border: 1px solid hsla(0, 0%, 4%, 0.15);
       }
     }
-    .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-selected {
-      background: #fff;
-      color: $ng-select-secondary-text;
-      position: relative;
-      :after {
-        position: absolute;
-        font-family: 'hxui';
-        content: '\E90F';
-        color: $ng-select-secondary-text;
-        font-size: 28px;
-        right: 0.5rem;
-      }
-    }
   }
   .ng-clear-wrapper {
     color: $ng-select-secondary-text;
@@ -354,6 +341,21 @@ $ng-select-danger: #b81e4f;
       &.marked {
         background: rgba(0, 0, 0, 0.05);
         color: #2a2c2d;
+      }
+    }
+  }
+  &.ng-select-multiple {
+    .ng-dropdown-panel-items .ng-option.ng-option-selected {
+      background: #fff;
+      color: $ng-select-secondary-text;
+      position: relative;
+      > ::after {
+        position: absolute;
+        font-family: 'hxui';
+        content: '\E90F';
+        color: $ng-select-secondary-text;
+        font-size: 28px;
+        right: 0.5rem;
       }
     }
   }

--- a/projects/ng-select/themes/select.stories.ts
+++ b/projects/ng-select/themes/select.stories.ts
@@ -56,13 +56,15 @@ class DataService {
         class="is-badge is-outlined"
       >
         <ng-template ng-label-tmp let-item="item" let-clear="clear">
-          <span class="hx-badge-content">
-            {{ item.name }}
-            <button
-              class="hx-delete is-small"
-              (click)="clear(item)"
-              aria-hidden="true"
-            ></button>
+          <span class="hx-badge is-outlined">
+            <span class="hx-badge-content">
+              {{ item.name }}
+              <button
+                class="hx-delete is-small"
+                (click)="clear(item)"
+                aria-hidden="true"
+              ></button>
+            </span>
           </span>
         </ng-template>
       </ng-select>


### PR DESCRIPTION
### Description

- Make dropdown styling for multi-select work as intended independently of its position in the dom

### Change

- [x] Bug fix (non-breaking change, fixes an issue)
- [ ] New feature (non-breaking change, adds functionality)
- [ ] Breaking change (causing existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist

- [x] I have self-reviewed my code
- [ ] I have added comments to my code for hard-to-understand areas
- [x] I have added tests that confirm my code works as intended
