### PR TITLE
deps: move non-publicly exposed deps from peer to

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,8 @@
         "@hxui/ng-select": "^1.1.0",
         "@ng-select/ng-option-highlight": "0.0.7",
         "@ng-select/ng-select": "^8.1.1",
-        "array-sort-by": "^1.2.1",
         "core-js": "^3.22.5",
         "highlight.js": "^11.5.1",
-        "lodash": "^4.17.21",
-        "lodash.clonedeep": "^4.5.0",
-        "moment": "^2.29.3",
         "ngx-highlightjs": "^6.1.2",
         "ngx-mask": "^13.1.13",
         "ngx-page-scroll": "^8.0.0",
@@ -68,6 +64,7 @@
         "@types/node": "^12.20.51",
         "@typescript-eslint/eslint-plugin": "5.3.0",
         "@typescript-eslint/parser": "5.3.0",
+        "array-sort-by": "^1.2.1",
         "babel-loader": "^8.2.5",
         "chromatic": "^6.5.4",
         "eslint": "^8.2.0",
@@ -76,7 +73,10 @@
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "lint-staged": "^12.4.1",
+        "lodash": "^4.17.20",
+        "lodash.clonedeep": "^4.5.0",
         "mini-css-extract-plugin": "^1.6.2",
+        "moment": "^2.29.0",
         "ng-packagr": "^13.3.1",
         "prettier": "^2.6.2",
         "typescript": "^4.4.4",
@@ -22221,7 +22221,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -22738,6 +22738,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array-sort-by/-/array-sort-by-1.2.1.tgz",
       "integrity": "sha512-n9/QOUEHspBsztm1rzKPQx0+tVIpAJf7QTTciLIArb6P4dvZ8fNlk8fhGGuCHkU1+oZtsnZAuPPYtaFEjEofIw==",
+      "dev": true,
       "dependencies": {
         "core-js": "^2.5.3"
       },
@@ -22749,7 +22750,8 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/array-union": {
@@ -29694,7 +29696,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -29716,7 +29718,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -37182,7 +37184,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -37855,12 +37857,14 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -38779,9 +38783,10 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -42001,7 +42006,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -46787,7 +46792,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -65096,7 +65101,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -65481,6 +65486,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array-sort-by/-/array-sort-by-1.2.1.tgz",
       "integrity": "sha512-n9/QOUEHspBsztm1rzKPQx0+tVIpAJf7QTTciLIArb6P4dvZ8fNlk8fhGGuCHkU1+oZtsnZAuPPYtaFEjEofIw==",
+      "dev": true,
       "requires": {
         "ajv": "^6.1.1",
         "core-js": "^2.5.3"
@@ -65489,7 +65495,8 @@
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
         }
       }
     },
@@ -70756,7 +70763,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -70775,7 +70782,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "devOptional": true
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -76471,7 +76478,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "devOptional": true
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -76961,12 +76968,14 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -77685,9 +77694,10 @@
       }
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true
     },
     "morgan": {
       "version": "1.10.0",
@@ -80116,7 +80126,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "devOptional": true
+      "dev": true
     },
     "qs": {
       "version": "6.10.3",
@@ -83842,7 +83852,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,8 @@
     "@hxui/ng-select": "^1.1.0",
     "@ng-select/ng-option-highlight": "0.0.7",
     "@ng-select/ng-select": "^8.1.1",
-    "array-sort-by": "^1.2.1",
     "core-js": "^3.22.5",
     "highlight.js": "^11.5.1",
-    "lodash": "^4.17.21",
-    "lodash.clonedeep": "^4.5.0",
-    "moment": "^2.29.3",
     "ngx-highlightjs": "^6.1.2",
     "ngx-mask": "^13.1.13",
     "ngx-page-scroll": "^8.0.0",
@@ -98,7 +94,11 @@
     "ng-packagr": "^13.3.1",
     "prettier": "^2.6.2",
     "typescript": "^4.4.4",
-    "webpack": "^5.30.0"
+    "webpack": "^5.30.0",
+    "array-sort-by": "^1.2.1",
+    "lodash": "^4.17.20",
+    "lodash.clonedeep": "^4.5.0",
+    "moment": "^2.29.0"
   },
   "lint-staged": {
     "*.{js,ts,html}": [

--- a/projects/hx-ui/ng-package.json
+++ b/projects/hx-ui/ng-package.json
@@ -4,5 +4,11 @@
   "deleteDestPath": false,
   "lib": {
     "entryFile": "src/public_api.ts"
-  }
+  },
+  "allowedNonPeerDependencies": [
+    "moment",
+    "array-sort-by",
+    "lodash",
+    "lodash.clonedeep"
+  ]
 }

--- a/projects/hx-ui/ng-package.prod.json
+++ b/projects/hx-ui/ng-package.prod.json
@@ -3,5 +3,11 @@
   "dest": "../../lib",
   "lib": {
     "entryFile": "src/public_api.ts"
-  }
+  },
+  "allowedNonPeerDependencies": [
+    "moment",
+    "array-sort-by",
+    "lodash",
+    "lodash.clonedeep"
+  ]
 }

--- a/projects/hx-ui/package.json
+++ b/projects/hx-ui/package.json
@@ -10,7 +10,10 @@
   },
   "bugs": "https://github.com/MedicalDirector/hxui-angular/issues",
   "dependencies": {
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "lodash": "^4.17.20",
+    "lodash.clonedeep": "^4.5.0",
+    "moment": "^2.29.0"
   },
   "peerDependencies": {
     "@angular/animations": "^13.0.0",
@@ -27,9 +30,6 @@
     "@ng-select/ng-option-highlight": "0.0.7",
     "@ng-select/ng-select": "^8.0.0",
     "array-sort-by": "^1.2.1",
-    "lodash": "^4.17.20",
-    "lodash.clonedeep": "^4.5.0",
-    "moment": "^2.29.0",
     "ngx-mask": "^13.0.0",
     "rxjs": "^7.4.0",
     "ngx-toastr": "^14.0.0"


### PR DESCRIPTION
### Description

Move peer deps that are not part of the public api over as normal deps:
- moment
- lodash
- lodash.clonedeep
- array-sort-by

### Change

- [ ] Bug fix (non-breaking change, fixes an issue)
- [ ] New feature (non-breaking change, adds functionality)
- [x] Breaking change (causing existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist

- [x] I have self-reviewed my code
- [ ] I have added comments to my code for hard-to-understand areas
- [ ] I have added tests that confirm my code works as intended
