### PR TITLE
fix(ng-select): support for panel width overrides

### DIFF
--- a/projects/ng-select/CHANGELOG.md
+++ b/projects/ng-select/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.0](https://www.npmjs.com/package/@hxui/ng-select/v/1.2.0) (2022-07-05)
+
+### Added
+
+- Added support for `custom-width` class. Use to then set width of dropdown panel items through custom templates.
+
 ### Changed
 
-- Styling for `ng-select-multiple` dropdown no longer depends on its location in the dom
+- Styling for `ng-select-multiple` dropdown no longer depends on its location in the dom.
 
 ## [1.1.1](https://www.npmjs.com/package/@hxui/ng-select/v/1.1.1) (2022-07-05)
 

--- a/projects/ng-select/package.json
+++ b/projects/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hxui/ng-select",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A HxUi theme for ng-select",
   "author": "Design @ MD <design@medicaldirector.com>",
   "private": false,

--- a/projects/ng-select/themes/hxui.theme.scss
+++ b/projects/ng-select/themes/hxui.theme.scss
@@ -317,6 +317,11 @@ $ng-select-danger: #b81e4f;
   .ng-spinner-zone {
     top: 3px;
   }
+
+  &.custom-width .ng-dropdown-panel {
+    width: auto !important;
+    // https://github.com/ng-select/ng-select/issues/1361#issuecomment-537837586
+  }
 }
 
 .ng-dropdown-panel {

--- a/src/app/page/select/example/custom-template.component.ts
+++ b/src/app/page/select/example/custom-template.component.ts
@@ -20,6 +20,7 @@ import { DataService, Person } from './data.service';
           placeholder="Select people"
           (keyup)="(onKeyup)"
           formControlName="selectedPersonId"
+          class="custom-width"
         >
           <ng-template ng-label-tmp let-item="item">
             <img height="15" width="15" [src]="item.picture" />


### PR DESCRIPTION
### Description

Add support for ng-select dropdown panel width overrides.

### Change

- [x] Bug fix (non-breaking change, fixes an issue)
- [ ] New feature (non-breaking change, adds functionality)
- [ ] Breaking change (causing existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist

- [x] I have self-reviewed my code
- [ ] I have added comments to my code for hard-to-understand areas
- [ ] I have added tests that confirm my code works as intended
